### PR TITLE
Fix: Handle ChromeDriver path for macOS

### DIFF
--- a/defines.py
+++ b/defines.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import sys
 
 ROOT_DIR = pathlib.Path(os.path.dirname(os.path.abspath(__file__)))
 
@@ -8,7 +9,10 @@ ALLOW_LESSON_MISSING = False
 
 DOWNLOAD_PATH = ROOT_DIR / "downloads"
 COOKIES_PATH = ROOT_DIR / "cookies"
-WEBDRIVER_PATH = ROOT_DIR / "webdrivers" / "chromedriver.exe"
+if sys.platform == "darwin":  # macOS
+    WEBDRIVER_PATH = ROOT_DIR / "webdrivers" / "chromedriver"
+else:
+    WEBDRIVER_PATH = ROOT_DIR / "webdrivers" / "chromedriver.exe"
 EXTENSIONS_PATH = ROOT_DIR / "extensions"
 DEFAULT_SESSION_FNAME = "last-saved.pkl"
 TIMEOUT = 120


### PR DESCRIPTION
The code previously hardcoded the ChromeDriver executable path with a ".exe" extension, which is incorrect for macOS. This change modifies  to conditionally set the  based on the operating system, using "chromedriver" (without the extension) for macOS and "chromedriver.exe" for other systems. This ensures that the code can run correctly on macOS.